### PR TITLE
Set tabindex on modal.

### DIFF
--- a/client/app/views/contact_name_modal.coffee
+++ b/client/app/views/contact_name_modal.coffee
@@ -10,6 +10,8 @@ module.exports = class CallImporterView extends BaseView
     id: 'namemodal'
     tagName: 'div'
     className: 'modal fade'
+    attributes:
+        tabindex: '-1'
 
     events:
         'click #cancel-btn': 'close'


### PR DESCRIPTION
This is for #20.

I couldn't `brunch build` locally to test.

``` bash
17:10:19 mihnea@light client master ? brunch build
08 Apr 17:10:23 - warn: config.paths.test was removed, use config.paths.watched 0 [ 'config.paths.test was removed, use config.paths.watched' ]
08 Apr 17:10:24 - error: Compiling of 'app/styles/application.styl' failed. stylus:685
   681|             display: none
   682|
   683|         input#filterfield
   684|             width: 100%
 > 685|

Arguments to path.join must be strings
```
